### PR TITLE
Fix typos/improve wording in L17

### DIFF
--- a/lectures/L17-slides.tex
+++ b/lectures/L17-slides.tex
@@ -295,7 +295,7 @@ This strategy is reasonably effective for a general-purpose, time-sharing operat
 \begin{frame}
 \frametitle{Upgrading to SVR4}
 
-SRV4: highest priority to real-time, then kernel, then user-mode.
+SVR4: highest priority to real-time, then kernel, then user-mode.
 
 Big differences are:\\
 \quad (1) more priority levels -- 160 broken down into three types\\
@@ -307,7 +307,7 @@ Preemption points were needed!
 
 \begin{frame}
 \frametitle{FreeBSD}
-FreedBSD has a scheduling process that's quite similar to that of SRV4.
+FreedBSD has a scheduling process that's quite similar to that of SVR4.
 
 Interactivity scoring mechanism: which are user-interactive?
 

--- a/lectures/L17.tex
+++ b/lectures/L17.tex
@@ -97,13 +97,13 @@ The $CPU$ and $N$ components of the equation are restricted to prevent a process
 
 Yes, unfortunately, user processes get piled at the bottom of the list. The use of the hierarchy should provide for efficient use of I/O devices and tends to penalize processor-bound processes at the expense of I/O bound processes. This is beneficial, because CPU-bound processes should be able to carry on executing when an I/O-bound process waits for the I/O operation to complete, but when an I/O operation is finished, we would like to start the next I/O operation so the I/O device is not waiting. This strategy is reasonably effective for a general-purpose, time-sharing operating system.
 
-\paragraph{Upgrading to SRV4.}
-In UNIX SRV4 the system for a complete overhaul, trying to give the highest priority to ``real-time'' processes, then kernel processes, and then user-mode preferences; its two big differences are (1) more priority levels -- 160 broken down into three types -- and (2) preemption points~\cite{osi}. 
+\paragraph{Upgrading to SVR4.}
+In UNIX SVR4 the system for a complete overhaul, trying to give the highest priority to ``real-time'' processes, then kernel processes, and then user-mode preferences; its two big differences are (1) more priority levels -- 160 broken down into three types -- and (2) preemption points~\cite{osi}. 
 
 Such preemption points are needed, because the original versions of the UNIX kernel were themselves not well-suited to preemption because it was not expected in the design that the kernel's execution could itself be preempted at any time. So preemption points are placed in the code where it would be okay for the kernel to stop execution and do another operation. In practice, this means that all kernel data structures are updated, or there are appropriate locks that would prevent concurrent modification and prevent race conditions~\cite{osi}. 
 
 \paragraph{FreeBSD.}
-BSD, the Berkeley Software Distribution, is another form of UNIX, and FreeBSD is one of its descendants. FreedBSD has a scheduling process that's quite similar to that of SRV4. There are more priority levels than SRV4 -- 256 rather than 160 -- and they are subdivided into five categories rather than just three. This implementation is intended to support multiprocessor systems better than the traditional UNIX approaches.
+BSD, the Berkeley Software Distribution, is another form of UNIX, and FreeBSD is one of its descendants. FreedBSD has a scheduling process that's quite similar to that of SVR4. There are more priority levels than SVR4 -- 256 rather than 160 -- and they are subdivided into five categories rather than just three. This implementation is intended to support multiprocessor systems better than the traditional UNIX approaches.
 
 What's new and interesting here is the interactivity scoring mechanism. Interactivity score is intended to identify which threads are user-interactive and which ones are CPU-intensive. Threads that are user-interactive should get a higher priority to run; in this system, lower numbers equal higher priority. Interactivity is judged based on how much the thread in question gets blocked: if it's waiting for the user or network or similar, then it would be considered interactive.
 

--- a/lectures/L17.tex
+++ b/lectures/L17.tex
@@ -135,7 +135,7 @@ A process is usually in the Normal class. Within that class there are some more 
 	Windows thread priorities~\cite{osc}.
 \end{center}
 
-If a process reaches the end of a time slice, the thread is interrupted, and unless it is in the real-time category, its priority will be lowered, to a minimum of a of the base priority of each class. When a process that was blocked on something (e.g., a wait or I/O), its priority is temporarily boosted (unless it is real-time, in which case it cannot be boosted). The amount of the boost depends on what the event was: a process that was waiting for keyboard input gets a bigger boost than one that was waiting for a disk operation, for example~\cite{osc}. 
+If a process reaches the end of a time slice, the thread is interrupted. If it is not in the real-time category, its priority will be lowered, to a minimum of the base priority of each class. When a process that was blocked on something (e.g., a wait or I/O) is unblocked, its priority is temporarily boosted (unless it is real-time, in which case it cannot be boosted). The amount of the boost depends on what the event was: a process that was waiting for keyboard input gets a bigger boost than one that was waiting for a disk operation, for example~\cite{osc}. 
 
 Windows also includes a little mechanism to make sure that a process does not starve; processes that have a low priority can temporarily get a boost to a priority of 15 to make sure that they get a chance to run and also to mitigate the impact of a potential priority inversion scenario~\cite{osi}.
 


### PR DESCRIPTION
### Very minor edits to Lecture 17
- Replace instances of 'SRV4' with 'SVR4' in both lecture notes and slides
- Add missing words "is unblocked" in lecture notes re: Windows dispatcher
- Update the wording of a sentence that I found difficult to parse in lecture notes re: Windows dispatcher

Not sure what triggers the autocompile, let me know if I should also include recompiled pdfs here.